### PR TITLE
fix int32

### DIFF
--- a/sys_linux.go
+++ b/sys_linux.go
@@ -65,10 +65,10 @@ func syncClock(d time.Duration, leap uint8, force bool) (err error) {
 			log.Printf("set offset slew offset=%s const=%d", d, con)
 		}
 		tmx.Modes = adjNANO | adjOFFSET | adjMAXERROR | adjESTERROR | adjTIMECONST
-		tmx.Offset = offsetNsec
+		tmx.Offset = int32(offsetNsec)
 		tmx.Maxerror = 0
 		tmx.Esterror = 0
-		tmx.Constant = con
+		tmx.Constant = int32(con)
 	} else {
 		if force {
 			if debug {


### PR DESCRIPTION
Hi,
I was compiling on a RPi P3 using the latest stable go  (go1.11.4 linux/arm)
and I got these errors:

```root@raspberrypi:~/gontpd# ../go/bin/go build -o gontp cmd/gontpd/main.go
# github.com/mengzhuo/gontpd
../go/src/github.com/mengzhuo/gontpd/sys_linux.go:68:14: cannot use offsetNsec (type int64) as type int32 in assignment
../go/src/github.com/mengzhuo/gontpd/sys_linux.go:71:16: cannot use con (type int64) as type int32 in assignment
```

I just correct those int type to make it work.
Feel free to merge if you see if useful.

Cheers